### PR TITLE
Update status to "Processing" after successful payment

### DIFF
--- a/onepay/includes/class-onepay.php
+++ b/onepay/includes/class-onepay.php
@@ -185,7 +185,7 @@ class Onepay extends WC_Payment_Gateway {
 
             $transactionCommitResponse = Transaction::commit($data['occ'], $externalUniqueNumber, $options);
 
-            $order->update_status('completed');
+            $order->update_status('processing');
             $order->payment_complete();
             $order->reduce_order_stock();
             WC()->cart->empty_cart();


### PR DESCRIPTION
Currently, when a payment is successful the status changes to "Completed", but it must change to "Processing".

This PR fixes that issue.