### PR TITLE
Fix error with permalinks different of plain

### DIFF
--- a/docker-php5.6/README.md
+++ b/docker-php5.6/README.md
@@ -45,6 +45,13 @@ cd docker-php5.6
 ./shell
 ```
 
+### Importante corregir permisos del directorio para instalar el plugin mediante zip
+
+```
+./shell root
+chown -R www-data:www-data /var/www/html/wp-content
+```
+
 ### Paneles
 
 **Web server:** http://localhost:8082

--- a/docker-php7.1/README.md
+++ b/docker-php7.1/README.md
@@ -45,6 +45,14 @@ cd docker-php7.1
 ./shell
 ```
 
+### Importante corregir permisos del directorio para instalar el plugin mediante zip
+
+```
+./shell root
+chown -R www-data:www-data /var/www/html/wp-content
+```
+
+
 ### Paneles
 
 **Web server:** http://localhost:8082

--- a/docker-php7.1/README.md
+++ b/docker-php7.1/README.md
@@ -1,0 +1,73 @@
+![Woocommerce](https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce@2x.png)
+
+#  Woocommerce Docker para desarrollo
+
+### PHP 7.1 + Mysql + Woocommerce  3.6.4
+
+### Requerimientos
+
+**MacOS:**
+
+Instalar [Docker](https://docs.docker.com/docker-for-mac/install/), [Docker-compose](https://docs.docker.com/compose/install/#install-compose) y [Docker-sync](https://github.com/EugenMayer/docker-sync/wiki/docker-sync-on-OSX).
+
+**Windows:**
+
+Instalar [Docker](https://docs.docker.com/docker-for-windows/install/), [Docker-compose](https://docs.docker.com/compose/install/#install-compose) y [Docker-sync](https://github.com/EugenMayer/docker-sync/wiki/docker-sync-on-Windows).
+
+**Linux:**
+
+Instalar [Docker](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/) y [Docker-compose](https://docs.docker.com/compose/install/#install-compose).
+
+### Como usar
+
+De forma automática se creará una imagen Wordpress, se instalará WooCommerce con el tema Storefront, se creará un producto de ejemplo y finalmente se activará este plugin.
+
+Para instalar Woocommerce, hacer lo siguiente:
+
+**NOTA:** La primera vez que se ejecuta ./start o ./build demorará en instalar todo, esperar al menos unos 5 minutos.
+
+### Construir el contenedor desde cero
+
+```
+cd docker-php7.1
+./build
+```
+
+### Iniciar el contenedor construido anteriormente
+
+```
+./start
+```
+
+### Acceder al contenedor
+
+```
+./shell
+```
+
+### Paneles
+
+**Web server:** http://localhost:8082
+
+**Admin:** http://localhost:8082/wp-admin
+
+    user: admin
+    password: admin
+
+## Extras para usar ngrok y probar en dominio virtual especialmente para emular producción
+
+1.- Ejecutar ngrok y obtener la url dada por ngrok en `Forwarding` http
+
+    ngrok http 8082
+
+2.- Modificar el archivo `init.sh` y reconstruir el docker
+
+    --url=URL_DADA_POR_NGROK
+
+    Ej: --url=c0c8db10.ngrok.io
+
+3.- Entrar al docker con `./shell` y agregar estas lineas a `wp-config.php`:
+
+    define('WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST']);
+    define('WP_HOME', 'http://' . $_SERVER['HTTP_HOST']);
+

--- a/docker-php7.1/Webserver.docker
+++ b/docker-php7.1/Webserver.docker
@@ -1,0 +1,13 @@
+FROM wordpress:5.2.2-php7.1-apache
+
+RUN php -r "copy('https://composer.github.io/installer.sig', '/composer-setup.sig');"
+RUN php -r "copy('https://getcomposer.org/installer', '/composer-setup.php');"
+RUN php -r "if (hash_file('SHA384', '/composer-setup.php') === trim(file_get_contents('/composer-setup.sig'))) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+RUN php /composer-setup.php --install-dir=/usr/local/bin --filename=composer
+RUN php -r "unlink('/composer-setup.php');"
+RUN php -r "unlink('/composer-setup.sig');"
+
+# install the PHP extensions we need
+RUN apt-get update && apt-get install -y zip unzip zlib1g-dev wget libxml2-dev nano
+RUN docker-php-ext-install zip
+RUN docker-php-ext-install soap

--- a/docker-php7.1/WordpressCli.docker
+++ b/docker-php7.1/WordpressCli.docker
@@ -1,0 +1,20 @@
+FROM wordpress:cli
+USER root
+RUN apk add --no-cache openssl less zip unzip git
+
+RUN php -r "copy('https://composer.github.io/installer.sig', '/composer-setup.sig');"
+RUN php -r "copy('https://getcomposer.org/installer', '/composer-setup.php');"
+RUN php -r "if (hash_file('SHA384', '/composer-setup.php') === trim(file_get_contents('/composer-setup.sig'))) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+RUN php /composer-setup.php --install-dir=/usr/local/bin --filename=composer
+RUN php -r "unlink('/composer-setup.php');"
+RUN php -r "unlink('/composer-setup.sig');"
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+# USER xfs
+
+ADD init.sh /
+WORKDIR /var/www/html/wp-content/plugins/onepay

--- a/docker-php7.1/build
+++ b/docker-php7.1/build
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+docker-compose build
+bash start

--- a/docker-php7.1/docker-compose.yml
+++ b/docker-php7.1/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.1'
+
+services:
+  webserver:
+    container_name: woocommerce
+    build:
+      context: .
+      dockerfile: Webserver.docker
+    volumes:
+    - data:/var/www/html
+    - ../onepay:/var/www/html/wp-content/plugins/onepay
+    environment:
+      WOOCOMMERCE_VERSION: 3.6.4
+      WORDPRESS_DB_PASSWORD: example
+      WORDPRESS_DEBUG: 1
+    depends_on:
+    - dbserver
+    ports:
+    - 8082:80
+
+  dbserver:
+    container_name: mysql
+    image: mariadb
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+
+  wplugin:
+    container_name: webpay_plugin
+    build:
+      context: .
+      dockerfile: WordpressCli.docker
+    volumes:
+    - data:/var/www/html
+    - ../onepay:/var/www/html/wp-content/plugins/onepay
+    depends_on:
+    - webserver
+    - dbserver
+
+    command: dockerize -wait tcp://dbserver:3306 -wait http://webserver:80 -timeout 40s sh /init.sh
+
+volumes:
+  data:

--- a/docker-php7.1/init.sh
+++ b/docker-php7.1/init.sh
@@ -1,0 +1,30 @@
+composer install
+wp --allow-root --allow-root core install --url=localhost:8082 --title=transbank --admin_user=admin --admin_password=admin --admin_email=transbankdevelopers@continuum.cl
+wp --allow-root plugin install woocommerce --version=3.4.0
+wp --allow-root plugin activate woocommerce
+wp --allow-root plugin activate onepay
+
+wp --allow-root wc tool run install_pages --user=admin
+wp --allow-root wc product create --name="Zapatos deportivos" --sku=1 --regular_price=1000 --status=publish --user=admin
+wp --allow-root wc product create --name="Zapatos formales" --sku=2 --regular_price=1500 --status=publish --user=admin
+wp --allow-root wc product create --name="Pelota" --sku=3 --regular_price=3 --status=publish --user=admin
+wp --allow-root theme install storefront
+wp --allow-root theme activate storefront
+wp --allow-root wc payment_gateway update onepay --enabled=true  --user=admin
+wp --allow-root db query "UPDATE wp_options SET option_value='CLP' WHERE option_name='woocommerce_currency';"
+wp --allow-root db query "UPDATE wp_options SET option_value='General Bustamante 24' WHERE option_name='woocommerce_store_address';"
+wp --allow-root db query "UPDATE wp_options SET option_value='Of M, Piso 7' WHERE option_name='woocommerce_store_address_2';"
+wp --allow-root db query "UPDATE wp_options SET option_value='Providencia' WHERE option_name='woocommerce_store_city';"
+wp --allow-root db query "UPDATE wp_options SET option_value='CL' WHERE option_name='woocommerce_default_country';"
+wp --allow-root db query "UPDATE wp_options SET option_value='7500000' WHERE option_name='woocommerce_store_postcode';"
+
+wp --allow-root db query "UPDATE wp_options SET option_value=0 WHERE option_name='woocommerce_price_num_decimals';"
+wp --allow-root db query "UPDATE wp_options SET option_value='.' WHERE option_name='woocommerce_price_thousand_sep';"
+wp --allow-root db query "UPDATE wp_options SET option_value=',' WHERE option_name='woocommerce_price_decimal_sep';"
+
+wp --allow-root config set WP_DEBUG true
+wp --allow-root config set --add --type=constant WP_DEBUG_LOG true
+wp --allow-root config set --add --type=constant WP_DEBUG_DISPLAY false
+wp --allow-root config set --add --type=constant WPS_DEBUG true
+wp --allow-root config set --add --type=constant WPS_DEBUG_SCRIPTS true
+wp --allow-root config set --add --type=constant WPS_DEBUG_STYLES true

--- a/docker-php7.1/init.sh
+++ b/docker-php7.1/init.sh
@@ -1,6 +1,6 @@
 composer install
 wp --allow-root --allow-root core install --url=localhost:8082 --title=transbank --admin_user=admin --admin_password=admin --admin_email=transbankdevelopers@continuum.cl
-wp --allow-root plugin install woocommerce --version=3.4.0
+wp --allow-root plugin install woocommerce --version=3.6.4
 wp --allow-root plugin activate woocommerce
 wp --allow-root plugin activate onepay
 

--- a/docker-php7.1/kill
+++ b/docker-php7.1/kill
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+docker-compose stop
+docker-compose down -v

--- a/docker-php7.1/shell
+++ b/docker-php7.1/shell
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+if [ -z "$1" ]
+  then
+    docker-compose exec --user www-data webserver bash
+else
+    docker-compose exec --user $@ webserver bash
+fi

--- a/docker-php7.1/start
+++ b/docker-php7.1/start
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+docker-compose up -d && \
+echo "
+========================================
+      🌎 Web server: http://localhost:8082
+      ⚙️ Admin: http://localhost:8082/wp-admin
+            user: admin
+            password: admin
+========================================"

--- a/docker-php7.1/stop
+++ b/docker-php7.1/stop
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker-compose stop

--- a/docker-php7.1/update
+++ b/docker-php7.1/update
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker-compose run --rm -w /var/www/html/wp-content/plugins/onepay webserver composer update

--- a/onepay/includes/class-onepay.php
+++ b/onepay/includes/class-onepay.php
@@ -162,7 +162,12 @@ class Onepay extends WC_Payment_Gateway {
      * @since    1.0.0
      */
     function commit_transaction($data) {
-
+        if(WC()->session == null) {
+            WC()->frontend_includes();
+            WC()->session = new WC_Session_Handler();
+            WC()->session->init();
+            wc_load_cart();
+        }
         $endpoint = $this->get_option('endpoint');
         $apiKey = $this->get_option('apikey');
         $sharedSecret = $this->get_option('shared_secret');
@@ -223,6 +228,11 @@ class Onepay extends WC_Payment_Gateway {
      * @since    1.0.0
      */
     function create_transaction($data) {
+
+        if (wc()->cart == null) {
+            wc()->frontend_includes();
+            wc_load_cart();
+        }
 
         if (isset($_POST['config']) && $_POST['config'] == 'true') {
 


### PR DESCRIPTION
on WooCommerce the cart and session information are not loaded when the admin configure the Permalinks with an option different of plain because WooCommerce do not detect that the url is a front api. So is necessary to load the session and cart if they are null.

additionally we add a docker with php 7.1 and WooCommerce 3.6.4