### PR TITLE
Prepare release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2019-07-08
+### Fixed
+- Corrige problema cuando se utiliza una configuración de Permalinks diferente a Plain.
+
 ## [1.1.0] - 2019-02-18
 ### Changed
 - Al recibir el pago de forma exitósa, el estado de la compra pasa a "Processing" en vez de "Completed".


### PR DESCRIPTION
See the full diff here: [v1.1.0...chore/prepare-release-1.1.1](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-onepay/compare/v1.1.0...chore/prepare-release-1.1.1)