### PR TITLE
remove session info on commit transaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-- '5.5'
+- '5.6'
 script: echo "We don't have tests yet :("
 before_deploy:
   - sh package.sh

--- a/onepay/includes/class-onepay.php
+++ b/onepay/includes/class-onepay.php
@@ -179,7 +179,7 @@ class Onepay extends WC_Payment_Gateway {
         OnepayBase::setCurrentIntegrationType($endpoint);
         $externalUniqueNumber = $data['externalUniqueNumber'];
         $occ = $data['occ'];
-        $sql = "SELECT post_id FROM wp_postmeta WHERE meta_key = 'occ' AND meta_value = ". $occ;
+        $sql = 'SELECT post_id FROM wp_postmeta WHERE meta_key = \'occ\' AND meta_value = ' . $occ;
         $result = $wpdb->get_results($sql);
         $order_id = $result[0]->post_id;
         $order = new WC_Order($order_id);


### PR DESCRIPTION
In the mobile case the user can use a navigator different of the default, in this case, when the onepay app returns to the web invoke the default browser that does not have the session data, displaying an error.
Now the method commit search the order in the database by OCC number, removing the error when using another browser.