### PR TITLE
Prepare release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2019-09-05
+### Fixed
+- Corrige problema en móvil cuando posterior al pago en la aplicación Onepay se retorna a un navegador diferente.
+
 ## [1.1.1] - 2019-07-08
 ### Fixed
 - Corrige problema cuando se utiliza una configuración de Permalinks diferente a Plain.


### PR DESCRIPTION
See the full diff here: [v1.1.1...chore/prepare-release-v1.1.2](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-onepay/compare/v1.1.1...chore/prepare-release-v1.1.2)